### PR TITLE
Fix updatePayment query conditions and DB operations

### DIFF
--- a/Waseda-SE/src/domain/payment/PaymentSqlDao.java
+++ b/Waseda-SE/src/domain/payment/PaymentSqlDao.java
@@ -33,9 +33,9 @@ public class PaymentSqlDao implements PaymentDao {
 	 */
 	public Payment getPayment(Date stayingDate, String roomNumber) throws PaymentException {
 		StringBuffer sql = new StringBuffer();
-		Statement statement = null;
-		ResultSet resultSet = null;
-		Connection connection = null;
+                Statement statement = null;
+                ResultSet resultSet = null;
+                Connection connection = null;
 		Payment payment = null;
 		try {
 			connection = getConnection();
@@ -74,7 +74,7 @@ public class PaymentSqlDao implements PaymentDao {
 	public void updatePayment(Payment payment) throws PaymentException {
 		StringBuffer sql = new StringBuffer();
 		Statement statement = null;
-		ResultSet resultSet = null;
+                ResultSet resultSet = null;
 		Connection connection = null;
 		try {
 			connection = getConnection();
@@ -83,11 +83,13 @@ public class PaymentSqlDao implements PaymentDao {
 			sql.append(TABLE_NAME);
 			sql.append(" SET status = '");
 			sql.append(payment.getStatus());
-			sql.append("' WHERE roomnumber='");
-			sql.append(payment.getRoomNumber());
-			sql.append("';");
+                        sql.append("' WHERE roomnumber='");
+                        sql.append(payment.getRoomNumber());
+                        sql.append("' AND stayingdate='");
+                        sql.append(DateUtil.convertToString(payment.getStayingDate()));
+                        sql.append("';");
 
-			resultSet = statement.executeQuery(sql.toString());
+                        statement.executeUpdate(sql.toString());
 		}
 		catch (SQLException e) {
 			PaymentException exception = new PaymentException(
@@ -96,18 +98,18 @@ public class PaymentSqlDao implements PaymentDao {
 			throw exception;
 		}
 		finally {
-			close(resultSet, statement, connection);
-		}
-	}
+                        close(null, statement, connection);
+                }
+        }
 
 	/**
 	 * @see domain.payment.PaymentDao#createPayment(domain.payment.Payment)
 	 */
 	public void createPayment(Payment payment) throws PaymentException {
 		StringBuffer sql = new StringBuffer();
-		Statement statement = null;
-		ResultSet resultSet = null;
-		Connection connection = null;
+                Statement statement = null;
+                ResultSet resultSet = null;
+                Connection connection = null;
 		try {
 			connection = getConnection();
 			statement = connection.createStatement();
@@ -120,10 +122,10 @@ public class PaymentSqlDao implements PaymentDao {
 			sql.append("', '");
 			sql.append(payment.getAmount());
 			sql.append("', '");
-			sql.append(payment.getStatus());
-			sql.append("');");
+                        sql.append(payment.getStatus());
+                        sql.append("');");
 
-			resultSet = statement.executeQuery(sql.toString());
+                        statement.executeUpdate(sql.toString());
 		}
 		catch (SQLException e) {
 			PaymentException exception = new PaymentException(
@@ -132,16 +134,16 @@ public class PaymentSqlDao implements PaymentDao {
 			throw exception;
 		}
 		finally {
-			close(resultSet, statement, connection);
-		}
-	}
+                        close(null, statement, connection);
+                }
+        }
 
 	/**
-	 * ƒf[ƒ^ƒx[ƒXƒRƒlƒNƒVƒ‡ƒ“‚ðŽæ“¾‚µ‚Ü‚·B<br>
+	 * ãƒ‡ãƒ¼ã‚¿ãƒ™ãƒ¼ã‚¹ã‚³ãƒã‚¯ã‚·ãƒ§ãƒ³ã‚’å–å¾—ã—ã¾ã™ã€‚<br>
 	 * 
-	 * @return ƒRƒlƒNƒVƒ‡ƒ“
+	 * @return ã‚³ãƒã‚¯ã‚·ãƒ§ãƒ³
 	 * @throws PaymentException
-	 *            ƒf[ƒ^ƒx[ƒXƒRƒlƒNƒVƒ‡ƒ“Žæ“¾‚ªŽ¸”s‚µ‚½ê‡‚É”­¶‚µ‚Ü‚·B
+	 *            ãƒ‡ãƒ¼ã‚¿ãƒ™ãƒ¼ã‚¹ã‚³ãƒã‚¯ã‚·ãƒ§ãƒ³å–å¾—ãŒå¤±æ•—ã—ãŸå ´åˆã«ç™ºç”Ÿã—ã¾ã™ã€‚
 	 */
 	private Connection getConnection() throws PaymentException {
 		Connection connection = null;


### PR DESCRIPTION
## Summary
- ensure `updatePayment` specifies `stayingdate` and uses `executeUpdate`
- use `executeUpdate` for `createPayment`
- clean up result set handling

## Testing
- `javac -cp dev_program_DB/lib/hsqldb.jar @sources.txt`

------
https://chatgpt.com/codex/tasks/task_e_687f664590048326a1b44fb22c5157ef