### PR TITLE
Use executeUpdate for update/insert operations

### DIFF
--- a/Waseda-SE/src/domain/payment/PaymentSqlDao.java
+++ b/Waseda-SE/src/domain/payment/PaymentSqlDao.java
@@ -74,7 +74,6 @@ public class PaymentSqlDao implements PaymentDao {
 	public void updatePayment(Payment payment) throws PaymentException {
 		StringBuffer sql = new StringBuffer();
 		Statement statement = null;
-		ResultSet resultSet = null;
 		Connection connection = null;
 		try {
 			connection = getConnection();
@@ -87,7 +86,7 @@ public class PaymentSqlDao implements PaymentDao {
 			sql.append(payment.getRoomNumber());
 			sql.append("';");
 
-			resultSet = statement.executeQuery(sql.toString());
+			statement.executeUpdate(sql.toString());
 		}
 		catch (SQLException e) {
 			PaymentException exception = new PaymentException(
@@ -96,7 +95,7 @@ public class PaymentSqlDao implements PaymentDao {
 			throw exception;
 		}
 		finally {
-			close(resultSet, statement, connection);
+			close(null, statement, connection);
 		}
 	}
 
@@ -106,8 +105,7 @@ public class PaymentSqlDao implements PaymentDao {
 	public void createPayment(Payment payment) throws PaymentException {
 		StringBuffer sql = new StringBuffer();
 		Statement statement = null;
-		ResultSet resultSet = null;
-		Connection connection = null;
+                Connection connection = null;
 		try {
 			connection = getConnection();
 			statement = connection.createStatement();
@@ -123,7 +121,7 @@ public class PaymentSqlDao implements PaymentDao {
 			sql.append(payment.getStatus());
 			sql.append("');");
 
-			resultSet = statement.executeQuery(sql.toString());
+			statement.executeUpdate(sql.toString());
 		}
 		catch (SQLException e) {
 			PaymentException exception = new PaymentException(
@@ -132,16 +130,16 @@ public class PaymentSqlDao implements PaymentDao {
 			throw exception;
 		}
 		finally {
-			close(resultSet, statement, connection);
+			close(null, statement, connection);
 		}
 	}
 
 	/**
-	 * ƒf[ƒ^ƒx[ƒXƒRƒlƒNƒVƒ‡ƒ“‚ðŽæ“¾‚µ‚Ü‚·B<br>
+	 * ãƒ‡ãƒ¼ã‚¿ãƒ™ãƒ¼ã‚¹ã‚³ãƒã‚¯ã‚·ãƒ§ãƒ³ã‚’å–å¾—ã—ã¾ã™ã€‚<br>
 	 * 
-	 * @return ƒRƒlƒNƒVƒ‡ƒ“
+	 * @return ã‚³ãƒã‚¯ã‚·ãƒ§ãƒ³
 	 * @throws PaymentException
-	 *            ƒf[ƒ^ƒx[ƒXƒRƒlƒNƒVƒ‡ƒ“Žæ“¾‚ªŽ¸”s‚µ‚½ê‡‚É”­¶‚µ‚Ü‚·B
+	 *            ãƒ‡ãƒ¼ã‚¿ãƒ™ãƒ¼ã‚¹ã‚³ãƒã‚¯ã‚·ãƒ§ãƒ³å–å¾—ãŒå¤±æ•—ã—ãŸå ´åˆã«ç™ºç”Ÿã—ã¾ã™ã€‚
 	 */
 	private Connection getConnection() throws PaymentException {
 		Connection connection = null;

--- a/Waseda-SE/src/domain/room/RoomSqlDao.java
+++ b/Waseda-SE/src/domain/room/RoomSqlDao.java
@@ -134,12 +134,11 @@ public class RoomSqlDao implements RoomDao {
 	 */
 	public void updateRoom(Room room) throws RoomException {
 		StringBuffer sql = new StringBuffer();
-		Statement statement = null;
-		Connection connection = null;
-		ResultSet resultSet = null;
-		try {
-			connection = getConnection();
-			statement = connection.createStatement();
+                Statement statement = null;
+                Connection connection = null;
+                try {
+                        connection = getConnection();
+                        statement = connection.createStatement();
 			sql.append("UPDATE ");
 			sql.append(TABLE_NAME);
 			sql.append(" SET stayingdate =");
@@ -153,18 +152,18 @@ public class RoomSqlDao implements RoomDao {
 				sql.append("'");
 			}
 			sql.append(" WHERE roomnumber='");
-			sql.append(room.getRoomNumber());
-			sql.append("';");
-			resultSet = statement.executeQuery(sql.toString());
-		}
-		catch (SQLException e) {
-			RoomException exception = new RoomException(RoomException.CODE_DB_EXEC_QUERY_ERROR, e);
-			exception.getDetailMessages().add("updateRoom()");
-			throw exception;
-		}
-		finally {
-			close(resultSet, statement, connection);
-		}
+                        sql.append(room.getRoomNumber());
+                        sql.append("';");
+                        statement.executeUpdate(sql.toString()); // executeUpdate を使用
+                }
+                catch (SQLException e) {
+                        RoomException exception = new RoomException(RoomException.CODE_DB_EXEC_QUERY_ERROR, e);
+                        exception.getDetailMessages().add("updateRoom()");
+                        throw exception;
+                }
+                finally {
+                        close(null, statement, connection); // ResultSet はないので null を渡す
+                }
 
 	}
 


### PR DESCRIPTION
## Summary
- use `executeUpdate` instead of `executeQuery` for updateRoom
- use `executeUpdate` for creating and updating payments
- close JDBC resources correctly for update/insert operations

## Testing
- `javac` compile all sources

------
https://chatgpt.com/codex/tasks/task_e_687f683f77d483269159af75ad4e5b61